### PR TITLE
Drop envmap from Experience.jsx

### DIFF
--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -8,7 +8,7 @@ export const Experience = () => {
     <>
       <Stage
         intensity={1.5}
-        environment="city"
+        environment={null}
         shadows={{
           type: "accumulative",
           color: "#d9afd9",


### PR DESCRIPTION
The city causes problems when loading (at least using a local server without any DNS records) and doesn't seem to be intended anyway.